### PR TITLE
Fix for #9: ThreadFactory for DaemonFactory.

### DIFF
--- a/simple/simple-common/src/main/java/org/simpleframework/common/thread/ConcurrentExecutor.java
+++ b/simple/simple-common/src/main/java/org/simpleframework/common/thread/ConcurrentExecutor.java
@@ -19,6 +19,7 @@
 package org.simpleframework.common.thread;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadFactory;
 
 /**
  * The <code>ConcurrentExecutor</code> object is used to execute tasks
@@ -44,7 +45,7 @@ public class ConcurrentExecutor implements Executor {
     * @param type this is the type of runnable that this accepts
     */
    public ConcurrentExecutor(Class type) {
-      this(type, 10);
+      this(type, 10, null);
    }
    
    /**
@@ -55,9 +56,10 @@ public class ConcurrentExecutor implements Executor {
     * 
     * @param type this is the type of runnable that this accepts
     * @param size this is the number of threads to use in the pool
+    * @param factory an optional {@link ThreadFactory}
     */   
-   public ConcurrentExecutor(Class type, int size) {
-      this(type, size, size);
+   public ConcurrentExecutor(Class type, int size, ThreadFactory factory) {
+      this(type, size, size, factory);
    }
    
    /**
@@ -69,9 +71,10 @@ public class ConcurrentExecutor implements Executor {
     * @param type this is the type of runnable that this accepts
     * @param rest this is the number of threads to use in the pool    
     * @param active this is the maximum size the pool can grow to 
+    * @param factory an optional {@link ThreadFactory}
     */   
-   public ConcurrentExecutor(Class type, int rest, int active) {     
-      this.queue = new ExecutorQueue(type, rest, active);
+   public ConcurrentExecutor(Class type, int rest, int active, ThreadFactory factory) {
+      this.queue = new ExecutorQueue(type, rest, active, factory);
    }   
    
    /**

--- a/simple/simple-common/src/main/java/org/simpleframework/common/thread/ConcurrentScheduler.java
+++ b/simple/simple-common/src/main/java/org/simpleframework/common/thread/ConcurrentScheduler.java
@@ -18,6 +18,7 @@
 
 package org.simpleframework.common.thread;
 
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -44,7 +45,7 @@ public class ConcurrentScheduler implements Scheduler {
     * @param type this is the type of the worker threads
     */
    public ConcurrentScheduler(Class type) {
-      this(type, 10);
+      this(type, 10, null);
    }
    
    /**
@@ -55,9 +56,10 @@ public class ConcurrentScheduler implements Scheduler {
     * 
     * @param type this is the type of the worker threads
     * @param size this is the number of threads for the scheduler
+    * @param factory an optional {@link ThreadFactory}
     */
-   public ConcurrentScheduler(Class type, int size) {
-      this.queue = new SchedulerQueue(type, size);
+   public ConcurrentScheduler(Class type, int size, ThreadFactory factory) {
+      this.queue = new SchedulerQueue(type, size, factory);
    }
 
    /**

--- a/simple/simple-common/src/main/java/org/simpleframework/common/thread/DaemonFactory.java
+++ b/simple/simple-common/src/main/java/org/simpleframework/common/thread/DaemonFactory.java
@@ -36,12 +36,18 @@ public class DaemonFactory implements ThreadFactory {
    private final Class type;   
    
    /**
+    * An optional {@link ThreadFactory}. If <code>null</code> the threads are
+    * created using {@link Thread} default constructor.
+    */
+	private final ThreadFactory threadFactory;
+
+   /**
     * Constructor for the <code>DaemonFactory</code> object. This 
     * will provide a thread factory that names the threads based 
     * on the type of <code>Runnable</code> the pool executes.
     */
    public DaemonFactory() {
-      this(null);
+      this(null, null);
    }   
    
    /**
@@ -51,9 +57,12 @@ public class DaemonFactory implements ThreadFactory {
     * of the threads is given a unique sequence number.
     * 
     * @param type this is the type of runnable this will execute
+    * @param factory an optional thread factory in which threads are to be 
+    *                created. The provided value might be <code>null</code>.
     */
-   public DaemonFactory(Class type) {
+   public DaemonFactory(Class type, ThreadFactory factory) {
       this.type = type;
+      this.threadFactory = factory;
    }
    
    /**
@@ -142,6 +151,11 @@ public class DaemonFactory implements ThreadFactory {
     * @return this returns a thread to execute the given task
     */
    private Thread createThread(Runnable task) {
+
+      if (threadFactory != null) {
+        return threadFactory.newThread(task);
+      }
+
       return new Thread(task);
    }
 }

--- a/simple/simple-common/src/main/java/org/simpleframework/common/thread/ExecutorQueue.java
+++ b/simple/simple-common/src/main/java/org/simpleframework/common/thread/ExecutorQueue.java
@@ -50,11 +50,6 @@ class ExecutorQueue {
    private final ThreadPoolExecutor executor;
    
    /**
-    * This is used to create the pool worker threads.
-    */
-   private final ThreadFactory factory;
-   
-   /**
     * Constructor for the <code>ExecutorQueue</code> object. This is
     * used to create a pool of threads that can be used to execute
     * arbitrary <code>Runnable</code> tasks. If the threads are
@@ -63,9 +58,10 @@ class ExecutorQueue {
     * @param type this is the type of runnable that this accepts
     * @param rest this is the number of threads to use in the pool    
     * @param active this is the maximum size the pool can grow to 
+    * @param factory an optional thread factory for threads
     */    
-   public ExecutorQueue(Class type, int rest, int active) {
-      this(type, rest, active, 120, TimeUnit.SECONDS);
+   public ExecutorQueue(Class type, int rest, int active, ThreadFactory factory) {
+      this(type, rest, active, factory, 120, TimeUnit.SECONDS);
    }
   
    /**
@@ -77,13 +73,13 @@ class ExecutorQueue {
     * @param type this is the type of runnable that this accepts
     * @param rest this is the number of threads to use in the pool    
     * @param active this is the maximum size the pool can grow to
+    * @param factory an optional thread factory for threads
     * @param duration the duration active threads remain idle for
     * @param unit this is the time unit used for the duration 
     */    
-   public ExecutorQueue(Class type, int rest, int active, long duration, TimeUnit unit) {
+   public ExecutorQueue(Class type, int rest, int active, ThreadFactory factory, long duration, TimeUnit unit) {
       this.queue = new LinkedBlockingQueue<Runnable>();
-      this.factory = new DaemonFactory(type);
-      this.executor = new ThreadPoolExecutor(rest, active, duration, unit, queue, factory);
+      this.executor = new ThreadPoolExecutor(rest, active, duration, unit, queue, new DaemonFactory(type, factory));
    }
    
    /**

--- a/simple/simple-common/src/main/java/org/simpleframework/common/thread/SchedulerQueue.java
+++ b/simple/simple-common/src/main/java/org/simpleframework/common/thread/SchedulerQueue.java
@@ -40,11 +40,6 @@ class SchedulerQueue {
    private final ScheduledThreadPoolExecutor executor;
    
    /**
-    * This is the factory used to create the worker threads.
-    */
-   private final ThreadFactory factory;
-   
-   /**
     * Constructor for the <code>SchedulerQueue</code> object. This 
     * will create a scheduler with a fixed number of threads to use
     * before execution. Depending on the types of task that are
@@ -52,10 +47,10 @@ class SchedulerQueue {
     * 
     * @param type this is the type of task to execute
     * @param size this is the number of threads for the scheduler
+    * @param factory an optional {@link ThreadFactory} 
     */   
-   public SchedulerQueue(Class type, int size) {
-      this.factory = new DaemonFactory(type);
-      this.executor = new ScheduledThreadPoolExecutor(size, factory);
+   public SchedulerQueue(Class type, int size, ThreadFactory factory) {
+      this.executor = new ScheduledThreadPoolExecutor(size, new DaemonFactory(type, factory));
    }
    
    /**

--- a/simple/simple-common/src/test/java/org/simpleframework/common/thread/SchedulerTest.java
+++ b/simple/simple-common/src/test/java/org/simpleframework/common/thread/SchedulerTest.java
@@ -12,7 +12,7 @@ public class SchedulerTest extends TestCase {
    private static final int ITERATIONS = 10000;
    
    public void testScheduler() throws Exception {
-      ConcurrentScheduler queue = new ConcurrentScheduler(Runnable.class, 10);
+      ConcurrentScheduler queue = new ConcurrentScheduler(Runnable.class, 10, null);
       LinkedBlockingQueue<Timer> list = new LinkedBlockingQueue<Timer>();
       
       for(int i = 0; i < ITERATIONS; i++) {

--- a/simple/simple-common/src/test/java/org/simpleframework/common/thread/TransientApplication.java
+++ b/simple/simple-common/src/test/java/org/simpleframework/common/thread/TransientApplication.java
@@ -9,7 +9,7 @@ public class TransientApplication {
 
    public static void main(String[] list) throws Exception {
       BlockingQueue queue = new LinkedBlockingQueue();
-      ConcurrentExecutor pool = new ConcurrentExecutor(TerminateTask.class, 10);      
+      ConcurrentExecutor pool = new ConcurrentExecutor(TerminateTask.class, 10, null);      
       
       for(int i = 0; i < 50; i++) {
          pool.execute(new LongTask(queue, String.valueOf(i)));

--- a/simple/simple-http/src/main/java/org/simpleframework/http/core/ContainerController.java
+++ b/simple/simple-http/src/main/java/org/simpleframework/http/core/ContainerController.java
@@ -21,6 +21,7 @@ package org.simpleframework.http.core;
 import static java.nio.channels.SelectionKey.OP_READ;
 
 import java.io.IOException;
+import java.util.concurrent.ThreadFactory;
 
 import org.simpleframework.common.buffer.Allocator;
 import org.simpleframework.common.thread.ConcurrentExecutor;
@@ -77,10 +78,11 @@ class ContainerController implements Controller {
     * @param allocator this is used to allocate any buffers needed
     * @param count this is the number of threads per thread pool
     * @param select this is the number of controller threads to use
+    * @param factory an optional {@link ThreadFactory}
     */
-   public ContainerController(Container container, Allocator allocator, int count, int select) throws IOException {
-      this.executor = new ConcurrentExecutor(RequestDispatcher.class, count); 
-      this.collect = new ConcurrentExecutor(RequestReader.class, count);
+   public ContainerController(Container container, Allocator allocator, int count, int select, ThreadFactory factory) throws IOException {
+      this.executor = new ConcurrentExecutor(RequestDispatcher.class, count, factory);
+      this.collect = new ConcurrentExecutor(RequestReader.class, count, null);
       this.reactor = new ExecutorReactor(collect, select);     
       this.allocator = allocator;
       this.container = container;

--- a/simple/simple-http/src/main/java/org/simpleframework/http/core/ContainerSocketProcessor.java
+++ b/simple/simple-http/src/main/java/org/simpleframework/http/core/ContainerSocketProcessor.java
@@ -19,13 +19,14 @@
 package org.simpleframework.http.core;
 
 import java.io.IOException;
+import java.util.concurrent.ThreadFactory;
 
 import org.simpleframework.common.buffer.Allocator;
 import org.simpleframework.common.buffer.FileAllocator;
+import org.simpleframework.transport.Socket;
+import org.simpleframework.transport.SocketProcessor;
 import org.simpleframework.transport.TransportProcessor;
 import org.simpleframework.transport.TransportSocketProcessor;
-import org.simpleframework.transport.SocketProcessor;
-import org.simpleframework.transport.Socket;
 
 /**
  * The <code>ContainerSocketProcessor</code> object is a connector
@@ -62,7 +63,7 @@ public class ContainerSocketProcessor implements SocketProcessor {
     * @param container this is the container used to service requests
     */
    public ContainerSocketProcessor(Container container) throws IOException {
-      this(container, 8);
+      this(container, 8, null);
    }
    
    /**
@@ -72,9 +73,11 @@ public class ContainerSocketProcessor implements SocketProcessor {
     * 
     * @param container this is the container used to service requests
     * @param count this is the number of threads used for each pool
+    * @param factory an optional {@link ThreadFactory} for request processing.
+    *                Can be <code>null</code>.
     */
-   public ContainerSocketProcessor(Container container, int count) throws IOException {
-      this(container, count, 1);
+   public ContainerSocketProcessor(Container container, int count, ThreadFactory factory) throws IOException {
+      this(container, count, 1, factory);
    }
    
    /**
@@ -85,9 +88,11 @@ public class ContainerSocketProcessor implements SocketProcessor {
     * @param container this is the container used to service requests
     * @param count this is the number of threads used for each pool
     * @param select this is the number of selector threads to use
+    * @param factory an optional {@link ThreadFactory} for request processing.
+    *                Can be <code>null</code>.
     */
-   public ContainerSocketProcessor(Container container, int count, int select) throws IOException {
-      this(container, new FileAllocator(), count, select);
+   public ContainerSocketProcessor(Container container, int count, int select, ThreadFactory factory) throws IOException {
+      this(container, new FileAllocator(), count, select, factory);
    }
    
    /**
@@ -99,7 +104,7 @@ public class ContainerSocketProcessor implements SocketProcessor {
     * @param allocator this is the allocator used to create buffers
     */   
    public ContainerSocketProcessor(Container container, Allocator allocator) throws IOException {
-      this(container, allocator, 8);
+      this(container, allocator, 8, null);
    } 
    
    /**
@@ -110,9 +115,11 @@ public class ContainerSocketProcessor implements SocketProcessor {
     * @param container this is the container used to service requests
     * @param allocator this is the allocator used to create buffers
     * @param count this is the number of threads used for each pool
+    * @param factory an optional {@link ThreadFactory} for request processing.
+    *                Can be <code>null</code>.
     */   
-   public ContainerSocketProcessor(Container container, Allocator allocator, int count) throws IOException {
-      this(container, allocator, count, 1);
+   public ContainerSocketProcessor(Container container, Allocator allocator, int count, ThreadFactory factory) throws IOException {
+      this(container, allocator, count, 1, factory);
    }   
    
    /**
@@ -124,9 +131,11 @@ public class ContainerSocketProcessor implements SocketProcessor {
     * @param allocator this is the allocator used to create buffers
     * @param count this is the number of threads used for each pool
     * @param select this is the number of selector threads to use
+    * @param factory an optional {@link ThreadFactory} for request processing.
+    *                Can be <code>null</code>.
     */   
-   public ContainerSocketProcessor(Container container, Allocator allocator, int count, int select) throws IOException {
-     this.processor = new ContainerTransportProcessor(container, allocator, count, select);
+   public ContainerSocketProcessor(Container container, Allocator allocator, int count, int select, ThreadFactory factory) throws IOException {
+     this.processor = new ContainerTransportProcessor(container, allocator, count, select, factory);
      this.adapter = new TransportSocketProcessor(processor, count); 
    }  
 

--- a/simple/simple-http/src/main/java/org/simpleframework/http/core/ContainerTransportProcessor.java
+++ b/simple/simple-http/src/main/java/org/simpleframework/http/core/ContainerTransportProcessor.java
@@ -19,11 +19,12 @@
 package org.simpleframework.http.core;
 
 import java.io.IOException;
+import java.util.concurrent.ThreadFactory;
 
 import org.simpleframework.common.buffer.Allocator;
-import org.simpleframework.transport.TransportProcessor;
 import org.simpleframework.transport.Transport;
 import org.simpleframework.transport.TransportChannel;
+import org.simpleframework.transport.TransportProcessor;
 
 /**
  * The <code>ContainerProcessor</code> object is used to create 
@@ -51,9 +52,11 @@ public class ContainerTransportProcessor implements TransportProcessor {
     * @param container the container to dispatch requests to
     * @param allocator this is the allocator used to buffer data
     * @param count this is the number of threads to be used
+    * @param factory an optional {@link ThreadFactory} for request processing.
+    *                Can be <code>null</code>.
     */
-   public ContainerTransportProcessor(Container container, Allocator allocator, int count) throws IOException {
-     this(container, allocator, count, 1);
+   public ContainerTransportProcessor(Container container, Allocator allocator, int count, ThreadFactory factory) throws IOException {
+     this(container, allocator, count, 1, factory);
    }  
  
    /**
@@ -66,9 +69,11 @@ public class ContainerTransportProcessor implements TransportProcessor {
     * @param allocator this is the allocator used to buffer data
     * @param count this is the number of threads to be used
     * @param select this is the number of controller threads to use
+    * @param factory an optional {@link ThreadFactory} for request processing.
+    *                Can be <code>null</code>.
     */
-   public ContainerTransportProcessor(Container container, Allocator allocator, int count, int select) throws IOException {
-     this.controller = new ContainerController(container, allocator, count, select);
+   public ContainerTransportProcessor(Container container, Allocator allocator, int count, int select, ThreadFactory factory) throws IOException {
+     this.controller = new ContainerController(container, allocator, count, select, factory);
    }        
 
    /**

--- a/simple/simple-http/src/main/java/org/simpleframework/http/socket/service/ServiceDispatcher.java
+++ b/simple/simple-http/src/main/java/org/simpleframework/http/socket/service/ServiceDispatcher.java
@@ -80,7 +80,7 @@ class ServiceDispatcher {
     * @param ping this is the frequency used to send ping frames
     */
    public ServiceDispatcher(Router router, int threads, long ping) throws IOException {
-      this.scheduler = new ConcurrentScheduler(FrameCollector.class, threads);      
+      this.scheduler = new ConcurrentScheduler(FrameCollector.class, threads, null);
       this.reactor = new ExecutorReactor(scheduler);
       this.builder = new SessionBuilder(scheduler, reactor, ping);
       this.dispatcher = new SessionDispatcher(builder, router);      

--- a/simple/simple-http/src/test/java/org/simpleframework/http/ConnectionTest.java
+++ b/simple/simple-http/src/test/java/org/simpleframework/http/ConnectionTest.java
@@ -100,7 +100,7 @@ public class ConnectionTest extends TestCase {
       
       public PingServer(int port, String message) throws Exception {
          Allocator allocator = new FileAllocator();
-         TransportProcessor processor  = new ContainerTransportProcessor(this, allocator, 5);
+         TransportProcessor processor  = new ContainerTransportProcessor(this, allocator, 5, null);
          SocketProcessor server = new TransportSocketProcessor(processor);
          DebugServer debug = new DebugServer(server);
          
@@ -149,7 +149,7 @@ public class ConnectionTest extends TestCase {
       private final List<java.net.Socket> sockets;
       
       public Pinger(int port, boolean socket, int count) throws Exception {
-         this.executor = new ConcurrentExecutor(Pinger.class, count);
+         this.executor = new ConcurrentExecutor(Pinger.class, count, null);
          this.list = new Vector<String>(count);
          this.sockets = new Vector<java.net.Socket>(count);
          this.latch = new CountDownLatch(count);

--- a/simple/simple-http/src/test/java/org/simpleframework/http/MockRenegotiationServer.java
+++ b/simple/simple-http/src/test/java/org/simpleframework/http/MockRenegotiationServer.java
@@ -71,7 +71,7 @@ public class MockRenegotiationServer implements Container {
 
    public MockRenegotiationServer(SSLContext context, boolean certRequired, int port) throws IOException {
       Allocator allocator = new FileAllocator();
-      ContainerTransportProcessor processor = new ContainerTransportProcessor(this, allocator, 4);
+      ContainerTransportProcessor processor = new ContainerTransportProcessor(this, allocator, 4, null);
       TransportGrabber grabber = new TransportGrabber(processor);
       TransportSocketProcessor processorServer = new TransportSocketProcessor(grabber);
       

--- a/simple/simple-http/src/test/java/org/simpleframework/http/core/ReactorProcessorTest.java
+++ b/simple/simple-http/src/test/java/org/simpleframework/http/core/ReactorProcessorTest.java
@@ -135,7 +135,7 @@ public class ReactorProcessorTest extends TestCase implements Container {
    private LinkedBlockingQueue<StopWatch> finished = new LinkedBlockingQueue<StopWatch>();
    
    public void testMinimal() throws Exception {
-      Controller handler = new ContainerController(this, new ArrayAllocator(), 10, 2);
+      Controller handler = new ContainerController(this, new ArrayAllocator(), 10, 2, null);
             
       testRequest(handler, "/MINIMAL/%s", MINIMAL, "MINIMAL");
       testRequest(handler, "/SIMPLE/%s", SIMPLE, "SIMPLE");

--- a/simple/simple-http/src/test/java/org/simpleframework/http/core/StopTest.java
+++ b/simple/simple-http/src/test/java/org/simpleframework/http/core/StopTest.java
@@ -52,7 +52,7 @@ public class StopTest extends TestCase {
    }
   
    public static Client createClient(InetSocketAddress address, String tag) throws Exception {
-      ConcurrentExecutor executor = new ConcurrentExecutor(Runnable.class, 20);
+      ConcurrentExecutor executor = new ConcurrentExecutor(Runnable.class, 20, null);
       int port = address.getPort();
       Client client = new Client(executor, port, tag);
 

--- a/simple/simple-http/src/test/java/org/simpleframework/http/core/WebSocketUpgradeTest.java
+++ b/simple/simple-http/src/test/java/org/simpleframework/http/core/WebSocketUpgradeTest.java
@@ -75,7 +75,7 @@ public class WebSocketUpgradeTest extends TestCase implements Container {
 
    public void testWebSocketUpgrade() throws Exception {      
       Allocator allocator = new ArrayAllocator();
-      Controller handler = new ContainerController(this, allocator, 10, 2);
+      Controller handler = new ContainerController(this, allocator, 10, 2, null);
       StreamCursor cursor = new StreamCursor(OPEN_HANDSHAKE);
       Channel channel = new MockChannel(cursor, 10);
       

--- a/simple/simple-http/src/test/java/org/simpleframework/http/socket/WebSocketChatApplication.java
+++ b/simple/simple-http/src/test/java/org/simpleframework/http/socket/WebSocketChatApplication.java
@@ -44,7 +44,7 @@ public class WebSocketChatApplication implements Container, TransportProcessor {
       this.negotiator = new DirectRouter(service);
       this.container = new RouterContainer(this, negotiator, 10);
       this.allocator = new ArrayAllocator();
-      this.processor = new ContainerTransportProcessor(container, allocator, 1);
+      this.processor = new ContainerTransportProcessor(container, allocator, 1, null);
       this.server = new TransportSocketProcessor(this);
       this.connection = new SocketConnection(server, agent);
       this.address = new InetSocketAddress(port);

--- a/simple/simple-http/src/test/java/org/simpleframework/http/socket/service/WebSocketPerformanceTest.java
+++ b/simple/simple-http/src/test/java/org/simpleframework/http/socket/service/WebSocketPerformanceTest.java
@@ -155,7 +155,7 @@ public class WebSocketPerformanceTest {
          this.negotiator = new DirectRouter(service);
          this.container = new RouterContainer(this, negotiator, 10, 100000);
          this.allocator = new ArrayAllocator();
-         this.processor = new ContainerTransportProcessor(container, allocator, 10);
+         this.processor = new ContainerTransportProcessor(container, allocator, 10, null);
          this.server = new TransportSocketProcessor(processor, 10, 8192*10);
          this.connection = new SocketConnection(server, agent);
          this.address = new InetSocketAddress(port);

--- a/simple/simple-http/src/test/java/org/simpleframework/http/socket/table/WebSocketTableUpdaterApplication.java
+++ b/simple/simple-http/src/test/java/org/simpleframework/http/socket/table/WebSocketTableUpdaterApplication.java
@@ -46,7 +46,7 @@ public class WebSocketTableUpdaterApplication implements Container, TransportPro
       this.negotiator = new DirectRouter(handler);
       this.container = new RouterContainer(this, negotiator, 10);
       this.allocator = new ArrayAllocator();
-      this.processor = new ContainerTransportProcessor(container, allocator, 1);
+      this.processor = new ContainerTransportProcessor(container, allocator, 1, null);
       this.server = new TransportSocketProcessor(this);
       this.connection = new SocketConnection(server, agent);
       this.address = new InetSocketAddress(port);

--- a/simple/simple-transport/src/main/java/org/simpleframework/transport/TransportSocketProcessor.java
+++ b/simple/simple-transport/src/main/java/org/simpleframework/transport/TransportSocketProcessor.java
@@ -125,7 +125,7 @@ public class TransportSocketProcessor implements SocketProcessor {
     * @param client determines if the SSL handshake is for a client
     */
    public TransportSocketProcessor(TransportProcessor processor, int threads, int buffer, int threshold, boolean client) throws IOException {
-      this.executor = new ConcurrentExecutor(Operation.class, threads);     
+      this.executor = new ConcurrentExecutor(Operation.class, threads, null);
       this.reactor = new ExecutorReactor(executor);
       this.factory = new OperationFactory(processor, reactor, buffer, threshold, client);
       this.cleaner = new ServerCleaner(processor, executor, reactor);

--- a/simple/simple-transport/src/test/java/org/simpleframework/transport/trace/CompareQueueTest.java
+++ b/simple/simple-transport/src/test/java/org/simpleframework/transport/trace/CompareQueueTest.java
@@ -20,9 +20,9 @@ public class CompareQueueTest extends TestCase {
    private static final int TEST_DURATION = 10000;
    private static final int THREAD_COUNT = 100;
    
-   private final Executor blockingReadExecutor = new ConcurrentExecutor(BlockingConsumer.class, THREAD_COUNT);
-   private final Executor concurrentReadExecutor = new ConcurrentExecutor(ConcurrentConsumer.class, THREAD_COUNT);
-   private final Executor writeExecutor = new ConcurrentExecutor(Producer.class, THREAD_COUNT);
+   private final Executor blockingReadExecutor = new ConcurrentExecutor(BlockingConsumer.class, THREAD_COUNT, null);
+   private final Executor concurrentReadExecutor = new ConcurrentExecutor(ConcurrentConsumer.class, THREAD_COUNT, null);
+   private final Executor writeExecutor = new ConcurrentExecutor(Producer.class, THREAD_COUNT, null);
    
    public void testLinkedBlockingQueue() throws Exception {
       BlockingQueue<Object> queue = new LinkedBlockingQueue<Object>();


### PR DESCRIPTION
Ok. So the main change is in the `ContainerContoller` class, where a `ThreadFactory` is accepted as an argument and passed to the `ConcurrentExecutor` that executes `Container` tasks **exclusively**. Everything else uses regular threads.

The other changes are to bring the factory to `DaemonFactory` across all the components.

I modified the constructors with this convention: any constructor that allows to customize the amount of threads will now accept a `ThreadFactory`. 

I attempted to mimic the existing code style as much as possible. But maybe it wasn't enough.

Just let me know if you'd like further changes.

Regards.
