### PR TITLE
Simple Framework SSL Bug Fixes

### DIFF
--- a/simple/pom.xml
+++ b/simple/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.simpleframework</groupId>
   <artifactId>simple</artifactId>
   <packaging>pom</packaging>
-  <version>6.0.1</version>
+  <version>6.0.2</version>
   <name>Simple</name>
   <modules>
     <module>simple-common</module>    

--- a/simple/simple-common/build.properties
+++ b/simple/simple-common/build.properties
@@ -1,3 +1,3 @@
-build.version=6.0.1
+build.version=6.0.2
 build.name=simple-common
 build.description=Simple Common

--- a/simple/simple-common/pom.xml
+++ b/simple/simple-common/pom.xml
@@ -8,7 +8,7 @@
   <groupId>org.simpleframework</groupId>
   <artifactId>simple-common</artifactId>
   <packaging>jar</packaging>
-  <version>6.0.1</version>
+  <version>6.0.2</version>
   <name>Simple Common</name>
   <url>http://www.simpleframework.org</url>
   <description>Simple is a high performance asynchronous HTTP framework for Java</description>
@@ -65,8 +65,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>

--- a/simple/simple-common/script/pom.xml
+++ b/simple/simple-common/script/pom.xml
@@ -65,8 +65,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>

--- a/simple/simple-common/src/main/java/org/simpleframework/common/buffer/FileBuffer.java
+++ b/simple/simple-common/src/main/java/org/simpleframework/common/buffer/FileBuffer.java
@@ -188,15 +188,14 @@ class FileBuffer implements Buffer {
     */   
    private String convert(InputStream source, String charset, int count) throws IOException {
       byte[] buffer = new byte[count];
-      int left = count;
       
-      while(left > 0) {
-         int size = source.read(buffer, 0, left);
+      int read;
+      for(int offset = 0; offset < count; offset+=read) {
+         read = source.read(buffer, offset, count-offset);
          
-         if(size == -1) {
+         if(read <= -1) {
             throw new BufferException("Could not read buffer");
          }
-         left -= count;
       }
       return new String(buffer, charset);
    }
@@ -530,10 +529,10 @@ class FileBuffer implements Buffer {
        */
       @Override
       public int read() throws IOException {
-         if(length-- > 0) {
+         if(length >= 1) {
+            length--;
             return in.read();
-         }
-         if(length <= 0) {
+         } else {
             close();
          }
          return -1;

--- a/simple/simple-http/build.properties
+++ b/simple/simple-http/build.properties
@@ -1,3 +1,3 @@
-build.version=6.0.1
+build.version=6.0.2
 build.name=simple-http
 build.description=Simple HTTP

--- a/simple/simple-http/pom.xml
+++ b/simple/simple-http/pom.xml
@@ -8,7 +8,7 @@
   <groupId>org.simpleframework</groupId>
   <artifactId>simple-http</artifactId>
   <packaging>jar</packaging>
-  <version>6.0.1</version>
+  <version>6.0.2</version>
   <name>Simple HTTP</name>
   <url>http://www.simpleframework.org</url>
   <description>Simple is a high performance asynchronous HTTP framework for Java</description>
@@ -40,12 +40,12 @@
     <dependency>
       <groupId>org.simpleframework</groupId>
       <artifactId>simple-common</artifactId>
-      <version>6.0.1</version>      
+      <version>6.0.2</version>
     </dependency>  
     <dependency>
       <groupId>org.simpleframework</groupId>
       <artifactId>simple-transport</artifactId>
-      <version>6.0.1</version>      
+      <version>6.0.2</version>
     </dependency>      
     <dependency>
       <groupId>junit</groupId>
@@ -75,8 +75,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>

--- a/simple/simple-http/script/pom.xml
+++ b/simple/simple-http/script/pom.xml
@@ -75,8 +75,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>

--- a/simple/simple-http/src/main/java/org/simpleframework/http/core/RequestCollector.java
+++ b/simple/simple-http/src/main/java/org/simpleframework/http/core/RequestCollector.java
@@ -78,7 +78,6 @@ class RequestCollector implements Collector {
     * an internal buffer to store the consumed body.
     * 
     * @param allocator this is the allocator used to buffer data
-    * @param tracker this is the tracker used to create sessions
     * @param channel this is the channel used to read the data
     */
    public RequestCollector(Allocator allocator, Channel channel) { 

--- a/simple/simple-transport/build.properties
+++ b/simple/simple-transport/build.properties
@@ -1,3 +1,3 @@
-build.version=6.0.1
+build.version=6.0.2
 build.name=simple-transport
 build.description=Simple Transport

--- a/simple/simple-transport/pom.xml
+++ b/simple/simple-transport/pom.xml
@@ -8,7 +8,7 @@
   <groupId>org.simpleframework</groupId>
   <artifactId>simple-transport</artifactId>
   <packaging>jar</packaging>
-  <version>6.0.1</version>
+  <version>6.0.2</version>
   <name>Simple Transport</name>
   <url>http://www.simpleframework.org</url>
   <description>Simple is a high performance asynchronous HTTP framework for Java</description>
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.simpleframework</groupId>
       <artifactId>simple-common</artifactId>
-      <version>6.0.1</version>      
+      <version>6.0.2</version>
     </dependency>  
     <dependency>
       <groupId>junit</groupId>
@@ -70,8 +70,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>

--- a/simple/simple-transport/script/pom.xml
+++ b/simple/simple-transport/script/pom.xml
@@ -70,8 +70,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>

--- a/simple/simple-transport/src/main/java/org/simpleframework/transport/Handshake.java
+++ b/simple/simple-transport/src/main/java/org/simpleframework/transport/Handshake.java
@@ -431,21 +431,15 @@ class Handshake implements Negotiation {
     * @return this returns true when the message has been read
     */
    public boolean receive() throws IOException {
-      int count = input.capacity();
-      
-      if(count > 0) {
-         input.compact();
-      }
+      input.compact();   // maximize read buffer
       int size = channel.read(input); 
+      input.flip();
 
       if(trace != null) {
         trace.trace(READ, size);
       }      
       if(size < 0) {
          throw new TransportException("Client closed connection");      
-      }
-      if(count > 0) {
-         input.flip(); 
       }
       return size > 0;
    }

--- a/simple/simple-transport/src/main/java/org/simpleframework/transport/NegotiationState.java
+++ b/simple/simple-transport/src/main/java/org/simpleframework/transport/NegotiationState.java
@@ -217,7 +217,7 @@ class NegotiationState implements Certificate {
        * completion of the SSL renegotiation results in the client
        * providing their certificate, and execution of the task. 
        * 
-       * @param completion task to be run on successful challenge
+       * @param task to be run on successful challenge
        */
       public Future<Certificate> challenge(Runnable task) {
          try {
@@ -238,7 +238,7 @@ class NegotiationState implements Certificate {
        * completion of the SSL renegotiation results in the client
        * providing their certificate, and execution of the task. 
        * 
-       * @param completion task to be run on successful challenge
+       * @param task to be run on successful challenge
        */
       private void resume(Runnable task) {
          try {

--- a/simple/simple-transport/src/main/java/org/simpleframework/transport/SocketBuffer.java
+++ b/simple/simple-transport/src/main/java/org/simpleframework/transport/SocketBuffer.java
@@ -125,7 +125,7 @@ class SocketBuffer {
     * 
     * @return this returns true if no reference was held
     */     
-   public synchronized boolean write(ByteBuffer duplicate) throws IOException {
+   public synchronized boolean write(ByteBuffer data) throws IOException {
       if(closed) {
          throw new TransportException("Buffer has been closed");
       }
@@ -135,22 +135,22 @@ class SocketBuffer {
       int count = appender.length();
       
       if(count > 0) {
-         return merge(duplicate);
+         return merge(data);
       }
-      int remaining = duplicate.remaining();
+      int remaining = data.remaining();
       
       if(remaining < chunk) {
-         appender.append(duplicate);// just save it..
+         appender.append(data);// just save it..
          return true;
       }
-      if(!flush(duplicate)) { // attempt a write
+      if(!flush(data)) { // attempt a write
          int space = appender.space();
          
          if(remaining < space) {
-            appender.append(duplicate);
+            appender.append(data);
             return true;
          }
-         reference = duplicate;
+         reference = data;
          return false;         
       }
       return true;
@@ -230,7 +230,6 @@ class SocketBuffer {
     * can be acquired from the <code>length</code> method. Once all
     * of the bytes are written the packet must be closed.
     *
-    * @param channel this is the channel to write the packet to
     * @param segment this is the segment that is to be written
     *
     * @return this returns the number of bytes that were written

--- a/simple/simple-transport/src/main/java/org/simpleframework/transport/TransportCursor.java
+++ b/simple/simple-transport/src/main/java/org/simpleframework/transport/TransportCursor.java
@@ -73,7 +73,7 @@ public class TransportCursor implements ByteCursor {
     * @param transport this is the underlying transport to use
     */  
    public TransportCursor(Transport transport) {
-      this(transport, 2048);
+      this(transport, 20*2048);
    }
    
    /**

--- a/simple/simple-transport/src/main/java/org/simpleframework/transport/TransportReader.java
+++ b/simple/simple-transport/src/main/java/org/simpleframework/transport/TransportReader.java
@@ -176,12 +176,16 @@ class TransportReader implements ByteReader {
       if(count > 0) {
          buffer.compact(); // compact the buffer
       }
-      count += transport.read(buffer); // how many were read
+      int read = transport.read(buffer); // how many were read
+
+      if(read > 0) {
+         count += read;
+      }
 
       if(count > 0) {
          buffer.flip(); // if there is something then flip
       }
-      if(count < 0) { // close when stream is fully read
+      if(read < 0 && count <= 0) { // close when stream is fully read
          close();
       }
       return count;
@@ -198,6 +202,9 @@ class TransportReader implements ByteReader {
     * @return this is the number of bytes that have been reset
     */
    public int reset(int size) throws IOException {
+      if (size <=0) {
+          throw new IllegalArgumentException("invalid size " + size + " while resetting");
+      }
       int mark = buffer.position();
       
       if(size > mark) {


### PR DESCRIPTION
1. Bumped version to 6.0.2
2. Bumped Java Source and Target version from 1.5 to 1.6
3. FileBuffer.java: convert has potential bug; simplified read() method
4. Handshake.java: improved receive() method
5: SecureTransport.java: Fixed Bugs
5.1:  receive() method where unwrap is only called when swap  buffer
      has data.  Should call unwarp() until SSLEngine has consumed and
      produced all bytes it could.  Noticed Bug when uploading huge
      files ( > 1 MB )
5.2:  send() method could potentially have same issue when wrapping.
5.3:  write() method improvements due changes in send() method
6: TransportReader: Fixed a potential bug where count is directly
      adjusted without checking read result